### PR TITLE
parameterize timing.properties

### DIFF
--- a/src/main/java/io/takari/maven/builder/smart/ProjectComparator.java
+++ b/src/main/java/io/takari/maven/builder/smart/ProjectComparator.java
@@ -150,6 +150,19 @@ class ProjectComparator {
   }
 
   private static File getTimingFile(MavenSession session) {
+    String myFolderProperty = System.getProperty("timing.properties.folder");
+    String myFileProperty = System.getProperty("timing.properties.file");
+    if (myFolderProperty != null) {
+      String myFileName = myFileProperty != null ? myFileProperty : "timing.properties";
+      File myFile = new File(myFolderProperty + File.separator+ myFileName);
+      myFile.getParentFile().mkdirs();
+      try {
+        myFile.createNewFile();
+      } catch (IOException aE) {
+        // no-op
+      }
+      return myFile;
+    }
     File mvndir = new File(session.getRequest().getBaseDirectory(), ".mvn");
     return mvndir.isDirectory() ? new File(mvndir, "timing.properties") : null;
   }

--- a/src/test/java/io/takari/maven/builder/smart/its/SmartBuilderIntegrationTest.java
+++ b/src/test/java/io/takari/maven/builder/smart/its/SmartBuilderIntegrationTest.java
@@ -47,4 +47,38 @@ public class SmartBuilderIntegrationTest {
     result = execution.execute("package");
     result.assertErrorFreeLog();
   }
+
+  @Test
+  public void testTimingProperty() throws Exception {
+    File basedir = resources.getBasedir("basic-it");
+    String myFolder = basedir + ".mvn/";
+    String myFile = "timing.properties.0";
+    MavenExecution execution = verifier.forProject(basedir) //
+        .withCliOptions("--builder", "smart") //
+        .withCliOption("-Dtiming.properties.folder=" + myFolder)
+        .withCliOption("-Dtiming.properties.file=" + myFile); //
+    MavenExecutionResult result = execution.execute("package");
+    result.assertErrorFreeLog();
+
+    TestResources.assertFilesPresent(new File(myFolder), myFile);
+
+    result = execution.execute("package");
+    result.assertErrorFreeLog();
+  }
+
+  @Test
+  public void testTimingPropertyWithFolderOnly() throws Exception {
+    File basedir = resources.getBasedir("basic-it");
+    String myFolder = basedir + ".mvn/";
+    MavenExecution execution = verifier.forProject(basedir) //
+        .withCliOptions("--builder", "smart") //
+        .withCliOption("-Dtiming.properties.folder=" + myFolder);
+    MavenExecutionResult result = execution.execute("package");
+    result.assertErrorFreeLog();
+
+    TestResources.assertFilesPresent(new File(myFolder), "timing.properties");
+
+    result = execution.execute("package");
+    result.assertErrorFreeLog();
+  }
 }


### PR DESCRIPTION
We want the ability to specify where the timing.properties file lives
and what its name is

Background:
We run multiple builds with different maven trees, on teamcity
agents where the .mvn folder is in a temp folder created for a run
only
