### PR TITLE
Optimize the log output of the smart builder

### DIFF
--- a/src/main/java/io/takari/maven/builder/smart/ReactorBuildStats.java
+++ b/src/main/java/io/takari/maven/builder/smart/ReactorBuildStats.java
@@ -137,7 +137,7 @@ class ReactorBuildStats {
     }
   }
 
-  private List<String> getBottleneckProjects() {
+  public List<String> getBottleneckProjects() {
     Comparator<String> comparator = (a, b) -> {
       long ta = bottleneckTimes.get(a).longValue();
       long tb = bottleneckTimes.get(b).longValue();

--- a/src/main/java/io/takari/maven/builder/smart/SmartBuilderImpl.java
+++ b/src/main/java/io/takari/maven/builder/smart/SmartBuilderImpl.java
@@ -1,5 +1,12 @@
 package io.takari.maven.builder.smart;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
@@ -24,16 +31,10 @@ import org.apache.maven.lifecycle.internal.ReactorContext;
 import org.apache.maven.lifecycle.internal.TaskSegment;
 import org.apache.maven.lifecycle.internal.builder.Builder;
 import org.apache.maven.project.MavenProject;
-import io.takari.maven.builder.smart.ProjectExecutorService.ProjectRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
+import io.takari.maven.builder.smart.ProjectExecutorService.ProjectRunnable;
 
 /**
  * Maven {@link Builder} implementation that schedules execution of the reactor modules on the build
@@ -168,7 +169,7 @@ class SmartBuilderImpl {
     } else if (buildSummary instanceof BuildFailure) {
       message = "FAILURE";
     } else if (buildSummary != null) {
-      logger.warn("Unexpected project build summary class {}", buildSummary.getClass());
+      logger.debug("Unexpected project build summary class {}", buildSummary.getClass());
       message = "UNKNOWN";
     }
     logger.debug("{} build of project {}:{}", message, project.getGroupId(), project.getArtifactId());


### PR DESCRIPTION
Currently the smartbuilder prints some messages that are more debug infos at the info level that are hard to understand for the user.

This change do the following:
- print start/stop messages at the debug level
- in the summary print only the average project wall time
- print the total concurrency as percentage
- if the effective concurrency is lower than 80% print a list of bottlenecks and a hint to the user how to get further details

An example output then might look like this:
```
[INFO] ------------------------------------------------------------------------
[INFO] Average project wall time: 0,28s
[INFO] Total concurrency: 48 %
[INFO] Bottleneck projects that decrease concurrency: (run build with -Dsmartbuilder.profiling=true for further details)
[INFO] 	- project:a
[INFO] 	- project:b
[INFO] 	- project:c
[INFO] ------------------------------------------------------------------------
```
