### PR TITLE
Reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
   </scm>
 
   <properties>
+    <project.build.outputTimestamp>2025-01-01T00:00:00Z</project.build.outputTimestamp>
     <takari.licenseHeader>https://raw.githubusercontent.com/takari/takari-pom/master/license-header-asl2.txt</takari.licenseHeader>
 
     <takari.javaSourceVersion>8</takari.javaSourceVersion>


### PR DESCRIPTION
This is in fact no needed, as Takari Lifecycle is
reproducible by default, but makes project be picked up by "reproducible reports".